### PR TITLE
Update release actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [master, dev]
 jobs:
   build:
     runs-on: ubuntu-18.04
@@ -26,21 +26,36 @@ jobs:
           set -ex
           PATH="$PATH:$PWD/lua_jeti/src"
           mkdir release-output
+          if [[ $GITHUB_REF = refs/heads/master ]]; then
+            OUTPUT_ZIP="release-output/DFM-Maps-v${DFM_MAPS_VERSION}.zip"
+          else
+            OUTPUT_ZIP="release-output/DFM-Maps-build${GITHUB_RUN_ID}.zip"
+          fi
 
           DFM_MAPS_VERSION=$(lua -e "print((require 'DFM-Maps').version)")
           echo "::set-output name=dfm_maps_version::${DFM_MAPS_VERSION}"
-          OUTPUT_ZIP="release-output/DFM-Maps-v${DFM_MAPS_VERSION}.zip"
 
           luac -o DFM-Maps.lc DFM-Maps.lua 
           zip -r $OUTPUT_ZIP DFM-Maps.lc DFM-Maps
       - name: Upload release asset
+        if: ${{ github.ref == 'refs/heads/master' }}
         id: upload-release-asset 
         uses: softprops/action-gh-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: release-v${{ steps.lc_build.outputs.dfm_maps_version }}-${{ github.sha }}
-          name: |
-            DFM-Maps version ${{ steps.lc_build.outputs.dfm_maps_version }} 
+          tag_name: release-v${{ steps.lc_build.outputs.dfm_maps_version }}
+          name: "DFM-Maps version ${{ steps.lc_build.outputs.dfm_maps_version }}"
+          files: |
+            release-output/*
+      - name: Upload dev asset
+        if: ${{ github.ref == 'refs/heads/dev' }}
+        id: upload-dev-asset 
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          tag_name: build-${{ github.run_id }}
+          name: "DFM-Maps build #${{ github.run_id }}"
           files: |
             release-output/*
 


### PR DESCRIPTION
- Name the releases on the master branch using only the version number, so it will fail if two commits in master have the same version number
- Upload zip files from development builds as pre-releases